### PR TITLE
Adição do typescript como depêndencia de desenvolvimento

### DIFF
--- a/server/ta-server/package.json
+++ b/server/ta-server/package.json
@@ -4,7 +4,9 @@
   "description": "Servidor do teaching assistant",
   "main": "ta-server.js",
   "scripts": {
-    "test": "jasmine --config=./spec/support/jasmine.json"
+    "test": "jasmine --config=./spec/support/jasmine.json",
+    "tsc": "./node_modules/typescript/bin/tsc",
+    "start": "npm run tsc && node typeScript/server/ta-server/ta-server.js"
   },
   "author": "Paulo Borba",
   "license": "MIT",
@@ -21,6 +23,7 @@
     "@types/request-promise": "^4.1.38",
     "jasmine": "^2.8.0",
     "jasmine-promises": "^0.4.1",
-    "request-promise": "^4.2.2"
+    "request-promise": "^4.2.2",
+    "typescript": "^3.3.3333"
   }
 }

--- a/tests-acceptance/package.json
+++ b/tests-acceptance/package.json
@@ -2,8 +2,8 @@
   "name": "testes-acceptance",
   "description": "Testes de aceitação do teaching assistant",
   "scripts": {
-    "tsc": "tsc",
-    "test": "protractor typeScript/config/config.js",
+    "tsc": "./node_modules/typescript/bin/tsc",
+    "test": "npm run tsc && protractor typeScript/config/config.js",
     "webdriver-update": "webdriver-manager update",
     "webdriver-start": "webdriver-manager start"
   },
@@ -16,12 +16,12 @@
     "chai-as-promised": "^7.0.0",
     "cucumber": "^2.3.0",
     "mkdirp": "^0.5.1",
-    "protractor-cucumber-framework": "^3.1.1"
+    "protractor-cucumber-framework": "^3.1.1",
+    "typescript": "^2.9.2"
   },
   "dependencies": {
     "cucumber-html-reporter": "^2.0.0",
     "protractor": "^5.1.2",
-    "ts-node": "^3.1.0",
-    "typescript": "^2.2.1"
+    "ts-node": "^3.1.0"
   }
 }


### PR DESCRIPTION
Adiciona o typescript como depêndencia de desenvolvimento e adiciona scripts para rodar ele no package.json, eliminando a necessidade de instalar ele globalmente, além disso adiciona no script de start e test a execução do tsc